### PR TITLE
Fix github security alert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.10</version>
+            <version>2.8.11.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.8.11.1 or later

Ref [github security altert](https://github.com/SpareBank1/sb1fs/network/alert/pom.xml/com.fasterxml.jackson.core:jackson-databind/closed)