### PR TITLE
Bump jackson-databind version in order to remediate github security alert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.11.1</version>
+            <version>2.8.11.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Github reports a vulnerability in `com.fasterxml.jackson.core:jackson-databind`. This issue appears to be fixed in `v 2.8.11.3`.